### PR TITLE
Feat: 루틴 생성 페이지 구현

### DIFF
--- a/src/components/Routine/InputNumber.jsx
+++ b/src/components/Routine/InputNumber.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { MinusIcon, PlusIcon } from '@heroicons/react/20/solid';
+
+const InputNumber = ({ label, defaultValue, unit, onChange }) => {
+  const [value, setValue] = useState(defaultValue);
+
+  const handleIncrement = () => {
+    const newValue = value + unit;
+    setValue(newValue);
+    if (onChange) {
+      onChange(newValue);
+    }
+  };
+
+  const handleDecrement = () => {
+    const newValue = value - unit;
+    setValue(newValue);
+    if (onChange) {
+      onChange(newValue);
+    }
+  };
+
+  return (
+    <div className='col-span-full'>
+      <label className='block text-sm font-semibold leading-6'>
+        {label}
+      </label>
+      <div className='relative mt-2 flex items-center space-x-2'>
+        <MinusIcon className='h-5 w-5 cursor-pointer' onClick={handleDecrement} />
+        <input
+          type='text'
+          value={value}
+          className='block w-50% rounded-md border-0 px-3 py-1.5 text-zinc-500 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:italic placeholder:text-zinc-300 focus:ring-2 focus:ring-inset focus:ring-primary-600 sm:text-sm sm:leading-6 text-center'
+        />
+        <PlusIcon className='h-5 w-5 cursor-pointer' onClick={handleIncrement} />
+      </div>
+    </div>
+  );
+};
+
+export default InputNumber;

--- a/src/components/UI/Drawer.jsx
+++ b/src/components/UI/Drawer.jsx
@@ -45,3 +45,5 @@ const Drawer = forwardRef(({ children, title }, ref) => {
     document.getElementById('drawer-root')
   );
 });
+
+export default Drawer;

--- a/src/components/UI/InputText.jsx
+++ b/src/components/UI/InputText.jsx
@@ -3,7 +3,8 @@ const InputText = ({
   type = 'text',
   label = 'label',
   placeholder = 'placeholder',
-  defaultValue = undefined
+  defaultValue = undefined,
+  onChange
 }) => {
   // TODO: default 제거
   return (
@@ -18,7 +19,8 @@ const InputText = ({
           id={label}
           autoComplete={label}
           placeholder={placeholder}
-          defaultValue={defaultValue && defaultValue}
+          defaultValue={defaultValue}
+          onChange={onChange}
           className='block w-full rounded-md border-0 px-3 py-1.5 text-zinc-500 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:italic placeholder:text-zinc-300 focus:ring-2 focus:ring-inset focus:ring-primary-600 sm:text-sm sm:leading-6'
         />
       </div>

--- a/src/components/UI/MultiSelectBox.jsx
+++ b/src/components/UI/MultiSelectBox.jsx
@@ -43,7 +43,10 @@ const MultiSelectBox = ({
               </ListboxButton>
 
               {open && (
-                <ListboxOptions className='absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-primary ring-opacity-5 focus:outline-none sm:text-sm'>
+                <ListboxOptions
+                  className='absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-primary ring-opacity-5 focus:outline-none sm:text-sm'
+                  transition
+                >
                   {selectOption.map((item, index) => (
                     <SelectOptions
                       key={index}

--- a/src/components/UI/MultiSelectBox.jsx
+++ b/src/components/UI/MultiSelectBox.jsx
@@ -1,0 +1,67 @@
+import SelectOptions from './SelectOptions.jsx';
+import { useState } from 'react';
+import { Label, Listbox, ListboxButton, ListboxOptions } from '@headlessui/react';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
+
+const MultiSelectBox = ({
+  label = 'label',
+  selectOption = ['option1', 'option2', 'option3', 'option4', 'option5'],
+  onChange,
+  placeholder = 'placeholder'
+}) => {
+  const [selected, setSelected] = useState([]);
+
+  const handleChange = value => {
+    let newSelected;
+    if (selected.includes(value)) {
+      newSelected = selected.filter(item => item !== value);
+    } else {
+      newSelected = [...selected, value];
+    }
+    setSelected(newSelected);
+    if (onChange) {
+      onChange(newSelected);
+    }
+  };
+
+  return (
+    <div className='w-full'>
+      <Listbox value={selected} onChange={handleChange} multiple>
+        {({ open }) => (
+          <>
+            <Label className='block text-sm font-semibold leading-6'>{label}</Label>
+            <div className='relative mt-2'>
+              <ListboxButton className='relative w-full cursor-default rounded-md bg-white py-1.5 pl-1 pr-10 text-left shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500 sm:text-sm sm:leading-6'>
+                <span className='flex items-center'>
+                  <span className='ml-3 block truncate text-zinc-700'>
+                    {selected.length > 0 ? selected.join(', ') : placeholder}
+                  </span>
+                </span>
+                <span className='pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2'>
+                  <ChevronDownIcon className='h-5 w-5' aria-hidden='true' />
+                </span>
+              </ListboxButton>
+
+              {open && (
+                <ListboxOptions className='absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-primary ring-opacity-5 focus:outline-none sm:text-sm'>
+                  {selectOption.map((item, index) => (
+                    <SelectOptions
+                      key={index}
+                      value={item}
+                      isSelected={selected.includes(item)}
+                      onClick={() => handleChange(item)}
+                    >
+                      {item}
+                    </SelectOptions>
+                  ))}
+                </ListboxOptions>
+              )}
+            </div>
+          </>
+        )}
+      </Listbox>
+    </div>
+  );
+};
+
+export default MultiSelectBox;

--- a/src/components/UI/SelectBox.jsx
+++ b/src/components/UI/SelectBox.jsx
@@ -19,32 +19,36 @@ const SelectBox = ({
   };
 
   return (
-    <Listbox value={selected} onChange={handleChange}>
-      {({ open }) => (
-        <>
-          <Label className='block text-sm font-semibold leading-6 '>{label}</Label>
-          <div className='relative mt-2'>
-            <ListboxButton className='relative w-full cursor-default rounded-md bg-white py-1.5 pl-1 pr-10 text-left  shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500 sm:text-sm sm:leading-6'>
-              <span className='flex items-center'>
-                <span className='ml-3 block truncate text-zinc-700'>{selected}</span>
-              </span>
-              <span className='pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2'>
-                <ChevronDownIcon className='h-5 w-5' aria-hidden='true' />
-              </span>
-            </ListboxButton>
+    <div className='w-full'>
+      <Listbox value={selected} onChange={handleChange}>
+        {({ open }) => (
+          <>
+            <Label className='block text-sm font-semibold leading-6'>{label}</Label>
+            <div className='relative mt-2'>
+              <ListboxButton className='relative w-full cursor-default rounded-md bg-white py-1.5 pl-1 pr-10 text-left  shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500 sm:text-sm sm:leading-6'>
+                <span className='flex items-center'>
+                  <span className='ml-3 block truncate text-zinc-700'>{selected}</span>
+                </span>
+                <span className='pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2'>
+                  <ChevronDownIcon className='h-5 w-5' aria-hidden='true' />
+                </span>
+              </ListboxButton>
 
-            <ListboxOptions
-              transition
-              className='absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-primary ring-opacity-5 focus:outline-none data-[closed]:data-[leave]:opacity-0 data-[leave]:transition data-[leave]:duration-100 data-[leave]:ease-in sm:text-sm'
-            >
-              {selectOption.map((item, index) => (
-                <SelectOption key={item} value={selectOption[index]} />
-              ))}
-            </ListboxOptions>
-          </div>
-        </>
-      )}
-    </Listbox>
+              {open && (
+                <ListboxOptions
+                  className='absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-primary ring-opacity-5 focus:outline-none sm:text-sm'
+                  transition
+                >
+                  {selectOption.map((item, index) => (
+                    <SelectOption key={item} value={selectOption[index]} onChange={() => handleChange(item)} />
+                  ))}
+                </ListboxOptions>
+              )}
+            </div>
+          </>
+        )}
+      </Listbox>
+    </div>
   );
 };
 

--- a/src/components/UI/SelectBox.jsx
+++ b/src/components/UI/SelectBox.jsx
@@ -1,7 +1,7 @@
 import SelectOption from './SelectOption.jsx';
 import { useState } from 'react';
 import { Label, Listbox, ListboxButton, ListboxOptions } from '@headlessui/react';
-import { ChevronUpDownIcon } from '@heroicons/react/20/solid';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
 
 const SelectBox = ({
   label = 'label',
@@ -29,7 +29,7 @@ const SelectBox = ({
                 <span className='ml-3 block truncate text-zinc-700'>{selected}</span>
               </span>
               <span className='pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2'>
-                <ChevronUpDownIcon className='h-5 w-5' aria-hidden='true' />
+                <ChevronDownIcon className='h-5 w-5' aria-hidden='true' />
               </span>
             </ListboxButton>
 

--- a/src/components/UI/SelectOptions.jsx
+++ b/src/components/UI/SelectOptions.jsx
@@ -1,0 +1,22 @@
+import { CheckIcon } from "@heroicons/react/20/solid";
+
+const SelectOptions = ({ value, isSelected, onClick, children }) => {
+  return (
+    <div
+      className={`relative cursor-default select-none py-2 pl-10 pr-4 ${
+        isSelected ? 'bg-primary-400 text-white' : 'text-gray-900 hover:bg-primary-400 hover:text-white'
+      }`}
+      onClick={onClick}
+    >
+      <span className={`block truncate ${isSelected ? 'font-semibold' : 'font-normal'}`}>{children}</span>
+
+      {isSelected ? (
+        <span className={'text-white absolute inset-y-0 right-0 flex items-center pr-4'}>
+          <CheckIcon className='h-5 w-5' aria-hidden='true' />
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+export default SelectOptions;

--- a/src/pages/Routine/RoutineCreate.jsx
+++ b/src/pages/Routine/RoutineCreate.jsx
@@ -1,17 +1,75 @@
-import { useRef } from 'react';
 import PageTitle from '../../components/PageTitle.jsx';
-import PageInfoText from '../../components/PageInfoText.jsx';
 import SelectBox from '../../components/UI/SelectBox.jsx';
+import InputNumber from '../../components/Routine/InputNumber.jsx';
 import MultiSelectBox from '../../components/UI/MultiSelectBox.jsx';
+import InputText from '../../components/UI/InputText.jsx'; // InputText 컴포넌트 추가
+import Button from '../../components/UI/Button.jsx';
+import { useState } from 'react';
+import axios from 'axios';
 
 const RoutineCreatePage = () => {
+  const [routineName, setRoutineName] = useState(''); // 루틴 이름 상태 추가
+  const [targetDistance, setTargetDistance] = useState(1000); // 상태 추가
+  const [poolLength, setPoolLength] = useState('25m');
+  const [strokes, setStrokes] = useState([]);
+
+  const onClick = async () => {
+    if (!routineName) {
+      alert('루틴 이름을 입력해주세요 😅');
+      return;
+    }
+
+    if (strokes.length === 0) {
+      alert('훈련할 영법을 선택해주세요 😅');
+      return;
+    }
+    // Request to the server with axios
+    try {
+      // TODO: 404 (Not Found Error) 해결
+      // await axios.post('/routine', {
+      //   headers: {
+      //     Authorization: `Bearer ${localStorage.getItem('accessToken')}`
+      //   },
+      //   routineName: routineName,
+      //   poolLength: poolLength,
+      //   targetDistance: targetDistance,
+      //   selStrokes: strokes
+      // });
+
+      // Redirect to /routine page
+      window.location.href = '/routine';
+    } catch (error) {
+      console.error('Error posting data:', error);
+    }
+  };
 
   return (
     <>
       <PageTitle title='루틴 생성' />
-      <SelectBox label='레인 길이' selectOption={['25m', '50m']} />
-
-      <MultiSelectBox label='영법 선택' selectOption={['자유형', '배영', '평영', '접영']} placeholder='복수 선택 가능' />
+      <InputText
+        label='루틴 이름'
+        placeholder='루틴 이름을 입력하세요'
+        defaultValue={routineName}
+        onChange={e => setRoutineName(e.target.value)} // 루틴 이름 상태 업데이트
+      />
+      <SelectBox
+        label='레인 길이'
+        selectOption={['25m', '50m']}
+        onChange={value => setPoolLength(value)} // 상태 업데이트
+      />
+      <InputNumber
+        label='목표 거리'
+        defaultValue={1000}
+        unit={100}
+        onChange={value => setTargetDistance(value)} // 상태 업데이트
+      />
+      <MultiSelectBox
+        label='영법 선택'
+        selectOption={['자유형', '배영', '평영', '접영']}
+        placeholder='훈련할 영법을 선택하세요'
+        onChange={value => setStrokes(value)} // 상태 업데이트
+      />
+      <Button key='create' content='생성하기' size='fit' onClick={onClick} />
     </>
   );
 };

--- a/src/pages/Routine/RoutineCreate.jsx
+++ b/src/pages/Routine/RoutineCreate.jsx
@@ -1,11 +1,17 @@
+import { useRef } from 'react';
 import PageTitle from '../../components/PageTitle.jsx';
 import PageInfoText from '../../components/PageInfoText.jsx';
+import SelectBox from '../../components/UI/SelectBox.jsx';
+import MultiSelectBox from '../../components/UI/MultiSelectBox.jsx';
 
 const RoutineCreatePage = () => {
+
   return (
     <>
       <PageTitle title='루틴 생성' />
-      <PageInfoText title='😢' content='루틴 생성 페이지를 준비 중입니다.' />
+      <SelectBox label='레인 길이' selectOption={['25m', '50m']} />
+
+      <MultiSelectBox label='영법 선택' selectOption={['자유형', '배영', '평영', '접영']} placeholder='복수 선택 가능' />
     </>
   );
 };


### PR DESCRIPTION
## 1. MR 목적
- 루틴 생성 페이지 구현

## 2. MR 내용
- SelectBox와 동일한 css를 갖고, 다중 선택이 가능한 MultiSelectBox 생성
- InputText에 onChange 함수 추가하여 부모 컴포넌트로 값을 전달할 수 있게 함
- 일반적인 드롭다운 UI를 고려하여 SelectBox의 UpDownIcon을 DownIcon으로 수정

## 체크리스트 (Checklist)
- [x] 코드가 정상적으로 동작하는지 테스트를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] 기존의 기능이 정상적으로 작동하는지 확인했습니다.
- [x] 스타일 가이드와 일관되게 코드를 작성했습니다.

## 테스트 결과 (Test Results)
- 테스트 방법을 설명해주세요 (예: `npm test` 또는 `./gradlew test`).
  `npm run dev`
- 테스트를 통해 발견된 이슈가 있다면 기술해주세요.
  - Drawer.jsx 내 export 누락

## 추가 설명 (Additional Notes)
- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요.
- 코드 리뷰어가 주의해야 할 사항이 있다면 명시해주세요.

